### PR TITLE
Use reference count for certain objects

### DIFF
--- a/Constraint.xsi
+++ b/Constraint.xsi
@@ -5,7 +5,7 @@ MODE: INLINE
 
 namespace xs {
     template <>
-    struct Typemap<kiwi::Constraint*> : TypemapObject<kiwi::Constraint*, kiwi::Constraint*, ObjectTypePtr, ObjectStorageMG, StaticCast> {
+    struct Typemap<kiwi::Constraint*> : TypemapObject<kiwi::Constraint*, kiwi::Constraint*, ObjectTypeRefcntPtr, ObjectStorageMG, StaticCast> {
         static std::string package () { return "Renard::API::Kiwisolver::Constraint"; }
     };
 }

--- a/Kiwisolver.xs
+++ b/Kiwisolver.xs
@@ -3,6 +3,8 @@ using namespace xs;
 
 #include <kiwi/kiwi.h>
 
+#include "Refcnt.xsi"
+
 MODULE = Renard::API::Kiwisolver                PACKAGE = Renard::API::Kiwisolver
 PROTOTYPES: DISABLE
 

--- a/Refcnt.xsi
+++ b/Refcnt.xsi
@@ -1,0 +1,33 @@
+namespace kiwi {
+	/* Implement reference counting for kiwi::Variable */
+	int* get_refcount( kiwi::Variable* obj ) {
+		return &( obj->m_data->m_refcount );
+	}
+
+	void refcnt_inc( kiwi::Variable* obj ) {
+		++(* kiwi::get_refcount( obj ) );
+	}
+	void refcnt_dec( kiwi::Variable* obj ) {
+		--(* kiwi::get_refcount( obj ) );
+	}
+	std::uint32_t refcnt_get( kiwi::Variable* obj ) {
+		return * kiwi::get_refcount( obj );
+	}
+}
+
+namespace kiwi {
+	/* Implement reference counting for kiwi::Constraint */
+	int* get_refcount( kiwi::Constraint* obj ) {
+		return &( obj->m_data->m_refcount );
+	}
+
+	void refcnt_inc( kiwi::Constraint* obj ) {
+		++(* kiwi::get_refcount( obj ) );
+	}
+	void refcnt_dec( kiwi::Constraint* obj ) {
+		--(* kiwi::get_refcount( obj ) );
+	}
+	std::uint32_t refcnt_get( kiwi::Constraint* obj ) {
+		return * kiwi::get_refcount( obj );
+	}
+}

--- a/Variable.xsi
+++ b/Variable.xsi
@@ -5,7 +5,7 @@ MODE: INLINE
 
 namespace xs {
     template <>
-    struct Typemap<kiwi::Variable*> : TypemapObject<kiwi::Variable*, kiwi::Variable*, ObjectTypePtr, ObjectStorageMG, StaticCast> {
+    struct Typemap<kiwi::Variable*> : TypemapObject<kiwi::Variable*, kiwi::Variable*, ObjectTypeRefcntPtr, ObjectStorageMG, StaticCast> {
         static std::string package () { return "Renard::API::Kiwisolver::Variable"; }
     };
 }

--- a/lib/Renard/API/Kiwisolver/Expression.pm
+++ b/lib/Renard/API/Kiwisolver/Expression.pm
@@ -7,8 +7,7 @@ use overload "fallback" => 0, '""' => \&stringify;
 sub stringify {
 	my ($self) = @_;
 	"(@{[ $self->constant ]} + "
-	.  " TERMS "
-	#.  join(" + ", map { "$_" } @{ $self->terms })
+	.  join(" + ", map { "$_" } @{ $self->terms })
 	. " : @{[ $self->value ]})"
 }
 

--- a/lib/Renard/API/Kiwisolver/Variable.pm
+++ b/lib/Renard/API/Kiwisolver/Variable.pm
@@ -6,7 +6,7 @@ use overload "fallback" => 0, '""' => \&stringify;
 
 sub stringify {
 	my ($self) = @_;
-	"(@{[ $self->name ]} : @{[ $self->value ]})"
+	"(@{[ $self->name || '[unnamed]' ]} : @{[ $self->value ]})"
 }
 
 1;

--- a/maint/cpanfile-git
+++ b/maint/cpanfile-git
@@ -3,4 +3,4 @@ requires 'Renard::Incunabula',
 	branch => 'master';
 requires 'Alien::Kiwisolver',
 	git => 'https://github.com/project-renard/p5-Alien-Kiwisolver.git',
-	branch => 'shared-ref';
+	branch => 'master';

--- a/maint/cpanfile-git
+++ b/maint/cpanfile-git
@@ -3,4 +3,4 @@ requires 'Renard::Incunabula',
 	branch => 'master';
 requires 'Alien::Kiwisolver',
 	git => 'https://github.com/project-renard/p5-Alien-Kiwisolver.git',
-	branch => 'master';
+	branch => 'shared-ref';

--- a/t/Renard/API/Kiwisolver/Expression.t
+++ b/t/Renard/API/Kiwisolver/Expression.t
@@ -1,0 +1,17 @@
+#!/usr/bin/env perl
+
+use Test::Most tests => 1;
+
+use Renard::Incunabula::Common::Setup;
+use Renard::API::Kiwisolver;
+
+subtest "Expression stringify" => fun() {
+	my $x = Renard::API::Kiwisolver::Variable->new('x');
+	my $y = Renard::API::Kiwisolver::Variable->new('y');
+	my $z = Renard::API::Kiwisolver::Variable->new('z');
+	my $expression = $x + 2*$y + 3*$z + 4;
+	note $expression;
+	pass;
+};
+
+done_testing;

--- a/t/Renard/API/Kiwisolver/Expression.t
+++ b/t/Renard/API/Kiwisolver/Expression.t
@@ -7,11 +7,13 @@ use Renard::API::Kiwisolver;
 
 subtest "Expression stringify" => fun() {
 	my $x = Renard::API::Kiwisolver::Variable->new('x');
+	$x->setValue(1);
 	my $y = Renard::API::Kiwisolver::Variable->new('y');
+	$y->setValue(2);
 	my $z = Renard::API::Kiwisolver::Variable->new('z');
-	my $expression = $x + 2*$y + 3*$z + 4;
-	note $expression;
-	pass;
+	$z->setValue(3);
+	my $expression = $x + (2*$y + (3*$z + 4));
+	is "$expression", "(4 + (3 * (z : 3) : 9) + (2 * (y : 2) : 4) + (1 * (x : 1) : 1) : 18)";
 };
 
 done_testing;

--- a/t/Renard/API/Kiwisolver/Variable.t
+++ b/t/Renard/API/Kiwisolver/Variable.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-use Test::Most tests => 3;
+use Test::Most tests => 4;
 
 use Renard::Incunabula::Common::Setup;
 use Renard::API::Kiwisolver;
@@ -32,6 +32,16 @@ subtest "Add operators" => fun() {
 	$y->setValue(6);
 	my $t = $x + $y;
 	is $t->value, 11, 'add up values';
+};
+
+subtest "Stringify" => fun() {
+	my $x = Variable->new('x');
+	$x->setValue(42);
+	my $whatever = Variable->new;
+	$whatever->setValue(32);
+
+	is "$x", '(x : 42)';
+	is "$whatever", '([unnamed] : 32)';
 };
 
 done_testing;


### PR DESCRIPTION
Since we are using pointers and sharing this with Perl, we need to keep
track of the reference count for certain kinds of objects that use
shared data on the C++ side. In particular, this is needed for
`kiwi::Variable` and `kiwi::Constraint`. This prevents a double free
error.

This requires a patch to the C++ code to access the necessary private
data. See <https://github.com/project-renard/p5-Alien-Kiwisolver/pull/2>.
